### PR TITLE
Update user experience

### DIFF
--- a/app/src/client/package.json
+++ b/app/src/client/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "paras",
-    "version": "1.0.0",
+    "name": "paras-webapp",
+    "version": "1.0.1",
     "private": true,
     "dependencies": {
         "@emotion/react": "^11.13.3",
@@ -19,8 +19,8 @@
         "smiles-drawer": "^2.1.7"
     },
     "scripts": {
-        "start": "react-scripts start",
-        "build": "react-scripts build",
+        "start": "REACT_APP_VERSION=$npm_package_version react-scripts start",
+        "build": "REACT_APP_VERSION=$npm_package_version react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject"
     },

--- a/app/src/client/src/components/SettingsModal.js
+++ b/app/src/client/src/components/SettingsModal.js
@@ -32,6 +32,8 @@ const SettingsModal = ({
     setSmilesFileContent,
     useOnlyUploadedSubstrates,
     setUseOnlyUploadedSubstrates,
+    uploadedSubstratesFileContentHasHeader,
+    setUploadedSubstratesFileContentHasHeader,
 }) => {
 
     // handle SMILES file upload for PARASECT
@@ -143,18 +145,49 @@ const SettingsModal = ({
                                 disabled={selectedModel !== 'parasect'}
                             />
                         </Box>
+                        
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                                gap: 0,
+                                marginTop: 2,
+                            }}
+                        >
+                            {/* option to use only uploaded substrates */}
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={useOnlyUploadedSubstrates}
+                                        onChange={(e) => setUseOnlyUploadedSubstrates(e.target.checked)}
+                                        disabled={!smilesFileContent}
+                                    />
+                                }
+                                label='Use only uploaded custom substrates'
+                            />
 
-                        {/* option to use only uploaded substrates */}
-                        <FormControlLabel
-                            control={
-                                <Checkbox
-                                    checked={useOnlyUploadedSubstrates}
-                                    onChange={(e) => setUseOnlyUploadedSubstrates(e.target.checked)}
-                                    disabled={!smilesFileContent}
+                            {/* option to specify if the uploaded substrates file has a header */}
+                            <Box
+                            // as row
+                                sx={{
+                                    display: 'flex',
+                                    justifyContent: 'left',
+                                    alignItems: 'center',
+                                    gap: 1,
+                                }}
+                            >
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            checked={uploadedSubstratesFileContentHasHeader}
+                                            onChange={(e) => setUploadedSubstratesFileContentHasHeader(e.target.checked)}
+                                            disabled={!smilesFileContent}
+                                        />
+                                    }
+                                    label='Uploaded custom substrates file has a header line with column names'
                                 />
-                            }
-                            label='Use only uploaded custom substrates'
-                        />
+                            </Box>
+                        </Box>
                     </Box>
                 </Box>
             </Box>

--- a/app/src/client/src/index.js
+++ b/app/src/client/src/index.js
@@ -60,7 +60,7 @@ const CustomToolbar = () => {
     const navigate = useNavigate();
 
     // version of the app
-    const [version, setVersion] = useState('');
+    const [version, setVersion] = useState('UNKNOWN');
 
     // fetch version from server
     useEffect(() => {
@@ -133,7 +133,7 @@ const CustomToolbar = () => {
                     sx={{ marginLeft: '16px' }}
                 >
                     <Typography sx={{ color: 'white.main' }}>
-                        PARAS {version}
+                        PARAS {version} (web app: v{process.env.REACT_APP_VERSION ? process.env.REACT_APP_VERSION : 'UNKNOWN'})
                     </Typography>
                 </Typography>
             </Toolbar>

--- a/app/src/client/src/pages/home.js
+++ b/app/src/client/src/pages/home.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography, Button, Link, Tooltip, Stack } from '@mui/material';
+import { Box, Typography, Button, Link, Tooltip } from '@mui/material';
 import ExitIcon from '@mui/icons-material/ExitToApp';
 
 /**

--- a/app/src/client/src/pages/results.js
+++ b/app/src/client/src/pages/results.js
@@ -58,7 +58,13 @@ const Results = () => {
                     throw new Error(data.message);
                 }; // else keep polling
             } catch (error) {
-                toast.error(error.message);
+                toast.error(
+                    <>
+                      {error.message}<br /><br />
+                      If you feel this is an error, or if you need assistance, please contact the developers in GitHub issues by selecting 'Report an issue' in the app bar at the top left of this page and posting your issue or question.
+                    </>,
+                    { autoClose: false }
+                );
                 setIsLoading(false);
                 clearInterval(intervalId);
             };

--- a/app/src/client/src/pages/submit.js
+++ b/app/src/client/src/pages/submit.js
@@ -49,6 +49,7 @@ const Submit = () => {
     // SMILES file state (for PARASECT model)
     const [smilesFileContent, setSmilesFileContent] = useState(''); // Stores content of uploaded SMILES file
     const [useOnlyUploadedSubstrates, setUseOnlyUploadedSubstrates] = useState(false); // Checkbox state
+    const [uploadedSubstratesFileContentHasHeader, setUploadedSubstratesFileContentHasHeader] = useState(true); // Checkbox state
 
     // modal state
     const [openSettingsModal, setOpenSettingsModal] = useState(false);
@@ -96,6 +97,7 @@ const Submit = () => {
             useStructureGuidedAlignment: useStructureGuidedAlignment,
             smilesFileContent: smilesFileContent,
             useOnlyUploadedSubstrates: useOnlyUploadedSubstrates,
+            uploadedSubstratesFileContentHasHeader: uploadedSubstratesFileContentHasHeader,
         };
 
         try {
@@ -283,6 +285,8 @@ const Submit = () => {
                 setSmilesFileContent={setSmilesFileContent}
                 useOnlyUploadedSubstrates={useOnlyUploadedSubstrates}
                 setUseOnlyUploadedSubstrates={setUseOnlyUploadedSubstrates}
+                uploadedSubstratesFileContentHasHeader={uploadedSubstratesFileContentHasHeader}
+                setUploadedSubstratesFileContentHasHeader={setUploadedSubstratesFileContentHasHeader}
             />
         </>
     );

--- a/app/src/server/routes/submit.py
+++ b/app/src/server/routes/submit.py
@@ -143,6 +143,11 @@ def run_prediction_raw(job_id: str, data: Dict[str, str]) -> None:
                 except Exception as e:
                     msg = f"failed to parse SMILES strings: {str(e)}"
                     raise Exception(msg)
+                
+                # if no custom substrates were provided, and also the option to use only uploaded substrates is selected
+                # return with error message that at least one custom substrate must be provided in that case
+                if len(custom_substrate_names) == 0 and use_only_uploaded_substrates:
+                    raise Exception("at least one custom substrate must be provided if 'Use only uploaded substrates' is selected.")
 
                 # run PARASECT
                 results = run_parasect(

--- a/app/src/server/routes/submit.py
+++ b/app/src/server/routes/submit.py
@@ -135,7 +135,7 @@ def run_prediction_raw(job_id: str, data: Dict[str, str]) -> None:
                             try:
                                 _ = read_smiles(smiles)
                             except Exception as e:
-                                msg = f"failed to parse SMILES string from custom substrates on line {line_index + 1} with name {smiles_name}: {str(e)}"
+                                msg = f"failed to parse SMILES string from custom substrates on line {line_index + 1} with name '{smiles_name}'. Error: {str(e)}"
                                 raise Exception(msg)
 
                             custom_substrate_names.append(smiles_name)

--- a/app/src/server/routes/submit.py
+++ b/app/src/server/routes/submit.py
@@ -13,6 +13,7 @@ from flask import Blueprint, Response, request, redirect
 
 from parasect.api import run_paras, run_parasect, run_paras_for_signatures
 from parasect.core.domain import AdenylationDomain
+from pikachu.general import read_smiles
 
 from .app import app
 from .common import ResponseData, Status
@@ -52,6 +53,7 @@ def run_prediction_raw(job_id: str, data: Dict[str, str]) -> None:
             use_structure_guided_alignment = data["useStructureGuidedAlignment"]
             smiles_file_content = data["smilesFileContent"]
             use_only_uploaded_substrates = data["useOnlyUploadedSubstrates"]
+            uploaded_substrates_file_has_header = data["uploadedSubstratesFileContentHasHeader"]
         except Exception as e:
             msg = f"failed to read settings: {str(e)}"
             raise Exception(msg)
@@ -121,8 +123,21 @@ def run_prediction_raw(job_id: str, data: Dict[str, str]) -> None:
                 try:
                     if len(smiles_file_content) > 0:
                         lines = smiles_file_content.strip().split("\n")
-                        for line in lines:
+                        for line_index, line in enumerate(lines):
+                            
+                            # skip header line if present
+                            if uploaded_substrates_file_has_header and line_index == 0:
+                                continue
+
                             smiles_name, smiles = line.strip().split("\t")
+
+                            # check if SMILES string is valid
+                            try:
+                                _ = read_smiles(smiles)
+                            except Exception as e:
+                                msg = f"failed to parse SMILES string from custom substrates on line {line_index + 1} with name {smiles_name}: {str(e)}"
+                                raise Exception(msg)
+
                             custom_substrate_names.append(smiles_name)
                             custom_substrate_smiles.append(smiles)
                 except Exception as e:


### PR DESCRIPTION
Improved features:

* Error message toasts don't auto-close anymore
* Make error messages actionable (i.e., 'If you feel this is an error, or need assistance, please reach out to the developers on GitHub.' etc.
* Added a check button for adding a list of custom substrates to indicate if the input file contains a header or not
* Added a separate web app version to the app bar